### PR TITLE
fixed issue with dragon after phoenix

### DIFF
--- a/src/ch/tichuana/tichu/commons/models/Combination.java
+++ b/src/ch/tichuana/tichu/commons/models/Combination.java
@@ -326,6 +326,10 @@ public enum Combination {
 					if (beforePhoenix != null && beforePhoenix.compareTo(newMove.get(0)) < 0){
 						return true;
 					} else {
+						// this is a bit ugly, only because clients do not hav the beforePhoenix initialized
+						if (newClone.get(0).getRank() == Rank.dragon){
+							return true;
+						}
 						return false;
 					}
 				}


### PR DESCRIPTION
Dragon can now be played after a phoenix.

Issue: only client who played phoenix has the beforePhoenix variable initialized. So it it will always jump to false.

fix: extra condition only client will reach: if previous card phoenix and this card dragon: return true